### PR TITLE
remove duplicate entry from `env_requirements.txt`

### DIFF
--- a/env_requirements.txt
+++ b/env_requirements.txt
@@ -1,4 +1,3 @@
-imbalanced-learn==0.9.1
 jupyter==1.0.0
 jupyter-console==6.4.3
 jupyter-core==4.10.0


### PR DESCRIPTION
`pip install` fails when detecting two separate versions of the same package.  

This addresses this issue by removing the duplicated entry of `imbalanced-learn` with a different version specified.